### PR TITLE
Revert "Fix incomplete LLVM installation..."

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,4 @@
 FROM debian:11 as build
 
-# Install GHC Haskell 8.8.4 and LLVM 12...
-RUN apt-get -y update && apt-get install -y ghc=8.8.4-2 wget \
-                           lsb-release software-properties-common gnupg && \
-    wget https://apt.llvm.org/llvm.sh && chmod +x llvm.sh && ./llvm.sh 12
-ENV PATH=/usr/lib/llvm-12/bin:$PATH
+# install ghc and llvm
+RUN apt-get -y update && apt-get install -y ghc=8.8.4-2 llvm-11

--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ It is published on Docker Hub as [primeimages/haskell](https://hub.docker.com/re
 Currently, it is based on:
 * [Debian 11](https://www.debian.org/News/2021/20210814)
 * [Haskell 8.8.4](https://www.haskell.org/ghc/download_ghc_8_8_4.html)
-* [LLVM 12](https://releases.llvm.org/download.html#12.0.1)
+* [LLVM 11](https://releases.llvm.org/download.html#11.0.1)


### PR DESCRIPTION
Reverts PlummersSoftwareLLC/Haskell-docker#2 because it doesn't work in this form with the ARM64 architecture since Debian 11 does not have Clang 12 as required on that architecture.